### PR TITLE
Add details to the overview page

### DIFF
--- a/docs/_index.md
+++ b/docs/_index.md
@@ -3,3 +3,7 @@ title: Juniper Mist
 meta_desc: The Juniper Mist provider for Pulumi can be used to provision any of the cloud resources available in Juniper Mist.
 layout: package
 ---
+
+The Juniper Mist Provider allows Pulumi to manage Juniper Mist Organizations.
+
+The Juniper Mist provider must be configured with credentials to deploy and update resources; see [Installation & Configuration](./installation-configuration/) for instructions.


### PR DESCRIPTION
Currently the overview page at https://www.pulumi.com/registry/packages/junipermist/ is blank and would be good to have some information on it.