### PR TITLE
Revert upstream error to warning for org inventory

### DIFF
--- a/patches/0002-revert-upstream-errors-to-warnings-for-org_inventory.patch
+++ b/patches/0002-revert-upstream-errors-to-warnings-for-org_inventory.patch
@@ -1,0 +1,23 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Venelin <venelin@pulumi.com>
+Date: Wed, 20 Nov 2024 18:39:21 +0000
+Subject: [PATCH] revert upstream errors to warnings for org_inventory
+
+
+diff --git a/internal/resource_org_inventory/sdk_to_terraform_legacy.go b/internal/resource_org_inventory/sdk_to_terraform_legacy.go
+index b344256..60575b4 100644
+--- a/internal/resource_org_inventory/sdk_to_terraform_legacy.go
++++ b/internal/resource_org_inventory/sdk_to_terraform_legacy.go
+@@ -141,10 +141,10 @@ func legacySdkToTerraform(
+ 			deviceFromMist.UnclaimWhenDestroyed = device.UnclaimWhenDestroyed
+ 			devicesOut = append(devicesOut, *deviceFromMist)
+ 		} else if magic != "" {
+-			diags.AddError("Device not found", fmt.Sprintf("Unable to find device with Claim Code \"%s\" in the Org Inventory", magic))
++			diags.AddWarning("Device not found", fmt.Sprintf("Unable to find device with Claim Code \"%s\" in the Org Inventory", magic))
+ 			devicesOut = append(devicesOut, NewDevicesValueNull())
+ 		} else if mac != "" {
+-			diags.AddError("Device not found", fmt.Sprintf("Unable to find device with MAC \"%s\" in the Org Inventory", mac))
++			diags.AddWarning("Device not found", fmt.Sprintf("Unable to find device with MAC \"%s\" in the Org Inventory", mac))
+ 			devicesOut = append(devicesOut, NewDevicesValueNull())
+ 		}
+ 	}


### PR DESCRIPTION
This PR adds a patch which reverts an upstream error back to a warning.


Temporary patch for https://github.com/pulumi/pulumi-junipermist/issues/190