### PR TITLE
Enable accurate bridge previews by default

### DIFF
--- a/provider/resources.go
+++ b/provider/resources.go
@@ -112,6 +112,7 @@ func Provider(_ context.Context) tfbridge.ProviderInfo {
 				"Pulumi": "3.*",
 			},
 		},
+		EnableAccurateBridgePreview: true,
 	}
 
 	tfbridge.MustTraverseProperties(&prov, "ids", applyResourceIDs)


### PR DESCRIPTION
This enables the Accurate Previews bridge feature for the provider.

part of pulumi/pulumi-terraform-bridge#2598