### PR TITLE
Generate registry docs

### DIFF
--- a/.ci-mgmt.yaml
+++ b/.ci-mgmt.yaml
@@ -23,3 +23,4 @@ integrationTestProvider: true
 
 # Use `pulumi convert` for translating examples from TF to Pulumi.
 pulumiConvert: 1
+registryDocs: true

--- a/.github/workflows/prerequisites.yml
+++ b/.github/workflows/prerequisites.yml
@@ -71,6 +71,8 @@ jobs:
       run: make prepare_local_workspace
     - name: Generate schema
       run: make schema
+    - name: Build registry docs
+      run: make build_registry_docs
     - name: Build provider binary
       run: make provider
     - name: Unit-test provider code

--- a/Makefile
+++ b/Makefile
@@ -44,7 +44,7 @@ LDFLAGS=$(LDFLAGS_PROJ_VERSION) $(LDFLAGS_UPSTREAM_VERSION) $(LDFLAGS_EXTRAS) $(
 _ := $(shell mkdir -p .make bin .pulumi/bin)
 
 # Build the provider and all SDKs and install ready for testing
-build: install_plugins provider build_sdks install_sdks
+build: install_plugins provider build_sdks install_sdks build_registry_docs
 # Keep aliases for old targets to ensure backwards compatibility
 development: build
 only_build: build
@@ -52,7 +52,7 @@ only_build: build
 # Importantly this is run by CI ahead of restoring the bin directory and resuming SDK builds
 prepare_local_workspace: install_plugins upstream
 # Creates all generated files which need to be committed
-generate: generate_sdks schema
+generate: generate_sdks schema build_registry_docs
 generate_sdks: generate_nodejs generate_python generate_dotnet generate_go generate_java
 build_sdks: build_nodejs build_python build_dotnet build_go build_java
 install_sdks: install_nodejs_sdk install_python_sdk install_dotnet_sdk install_go_sdk install_java_sdk
@@ -173,6 +173,12 @@ build_python: .make/build_python
 		../venv/bin/python -m build .
 	@touch $@
 .PHONY: generate_python build_python
+# Run the bridge's registry-docs command to generated the content of the installation docs/ folder at provider repo root
+build_registry_docs: .make/build_registry_docs
+.make/build_registry_docs: .make/install_plugins bin/$(CODEGEN)
+	bin/$(CODEGEN) registry-docs --out $(WORKING_DIR)/docs
+	@touch $@
+.PHONY: build_registry_docs
 
 clean:
 	rm -rf sdk/{dotnet,nodejs,go,python}

--- a/docs/_index.md
+++ b/docs/_index.md
@@ -19,7 +19,7 @@ The Juniper Mist provider is available as a package in all Pulumi languages:
 
 The Mist Provider allows Pulumi to manage Juniper Mist Organizations.
 
-It is mainly focusing on day 0 and day 1 operations (provisionning and delpyment) but will be completed over time.
+It is mainly focusing on day 0 and day 1 operations (provisioning and deployment) but will be completed over time.
 
 Use the navigation tree to the left to read about the available resources and functions.
 

--- a/docs/_index.md
+++ b/docs/_index.md
@@ -1,39 +1,159 @@
 ---
-title: Juniper Mist
-meta_desc: The Juniper Mist provider for Pulumi can be used to provision any of the cloud resources available in Juniper Mist.
+# *** WARNING: This file was auto-generated. Do not edit by hand unless you're certain you know what you are doing! ***
+title: Juniper Mist Provider
+meta_desc: Provides an overview on how to configure the Pulumi Juniper Mist provider.
 layout: package
 ---
 
-The Juniper Mist Provider allows Pulumi to manage Juniper Mist Organizations.
+## Installation
 
-The Juniper Mist provider must be configured with credentials to deploy and update resources; see [Installation & Configuration](./installation-configuration/) for instructions.
+The Juniper Mist provider is available as a package in all Pulumi languages:
 
-## Example
+* JavaScript/TypeScript: [`@pulumi/junipermist`](https://www.npmjs.com/package/@pulumi/junipermist)
+* Python: [`pulumi-junipermist`](https://pypi.org/project/pulumi-junipermist/)
+* Go: [`github.com/pulumi/pulumi-junipermist/sdk/go/junipermist`](https://github.com/pulumi/pulumi-junipermist)
+* .NET: [`Pulumi.Junipermist`](https://www.nuget.org/packages/Pulumi.Junipermist)
+* Java: [`com.pulumi/junipermist`](https://central.sonatype.com/artifact/com.pulumi/junipermist)
 
-{{< chooser language "typescript,python" >}}
+## Overview
 
+The Mist Provider allows Pulumi to manage Juniper Mist Organizations.
+
+It is mainly focusing on day 0 and day 1 operations (provisionning and delpyment) but will be completed over time.
+
+Use the navigation tree to the left to read about the available resources and functions.
+
+It is possible to use API Token or Username/Password authentication (without 2FA), but only one method should be configured.
+## Supported Mist Clouds
+
+This provider can be used with the following Mist Clouds:
+* Global 01 (api.mist.com)
+* Global 02 (api.gc1.mist.com)
+* Global 03 (api.ac2.mist.com)
+* Global 04 (api.gc2.mist.com)
+* EMEA 01 (api.eu.mist.com)
+* EMEA 02 (api.gc3.mist.com)
+* EMEA 03 (api.ac6.mist.com)
+* APAC 01 (api.ac5.mist.com)
+## Configuration
+### Provider configuration example
+
+{{< chooser language "typescript,python,go,csharp,java,yaml" >}}
 {{% choosable language typescript %}}
+```yaml
+# Pulumi.yaml provider configuration file
+name: configuration-example
+runtime: nodejs
+config:
+    mist:apitoken:
+        value: xxxxxxxxxxxxxxxxxxxxxxxxxxx
+    mist:host:
+        value: api.mist.com
 
-```typescript
-import * as junipermist from "@pulumi/juniper-mist";
-
-new junipermist.site.Wlan("wlan-one", {
-  ssid: "wlan_one",
-  siteId: site.id,
-});
 ```
 
 {{% /choosable %}}
 {{% choosable language python %}}
+```yaml
+# Pulumi.yaml provider configuration file
+name: configuration-example
+runtime: python
+config:
+    mist:apitoken:
+        value: xxxxxxxxxxxxxxxxxxxxxxxxxxx
+    mist:host:
+        value: api.mist.com
 
-```python
-import pulumi_juniper_mist as junipermist
-
-wlan = junipermist.site.Wlan(
-    "wlan-one", site_id=site.id, ssid="wlan_one"
-)
 ```
 
 {{% /choosable %}}
+{{% choosable language csharp %}}
+```yaml
+# Pulumi.yaml provider configuration file
+name: configuration-example
+runtime: dotnet
+config:
+    mist:apitoken:
+        value: xxxxxxxxxxxxxxxxxxxxxxxxxxx
+    mist:host:
+        value: api.mist.com
 
+```
+
+{{% /choosable %}}
+{{% choosable language go %}}
+```yaml
+# Pulumi.yaml provider configuration file
+name: configuration-example
+runtime: go
+config:
+    mist:apitoken:
+        value: xxxxxxxxxxxxxxxxxxxxxxxxxxx
+    mist:host:
+        value: api.mist.com
+
+```
+
+{{% /choosable %}}
+{{% choosable language yaml %}}
+```yaml
+# Pulumi.yaml provider configuration file
+name: configuration-example
+runtime: yaml
+config:
+    mist:apitoken:
+        value: xxxxxxxxxxxxxxxxxxxxxxxxxxx
+    mist:host:
+        value: api.mist.com
+
+```
+
+{{% /choosable %}}
+{{% choosable language java %}}
+```yaml
+# Pulumi.yaml provider configuration file
+name: configuration-example
+runtime: java
+config:
+    mist:apitoken:
+        value: xxxxxxxxxxxxxxxxxxxxxxxxxxx
+    mist:host:
+        value: api.mist.com
+
+```
+
+{{% /choosable %}}
 {{< /chooser >}}
+### Credentials
+
+Users are encouraged to pass the API Token or the username and password via the
+environment variables (see below). If authentication information are provided
+in the provider configuration and in the environment variables, the Provider
+configuration will be used.
+
+Please consider whether writing credentials to a configuration file is
+acceptable in your environment.
+### Proxy Support
+
+HTTP, HTTPS, and SOCKS5 proxies are supported through the `MIST_PROXY` environment
+variables or the `proxy` provider configuration attribute.
+## Configuration Reference
+
+- `apiDebug` (Boolean) Flag to enable debugging API calls. Default is false.
+- `apiTimeout` (Number) Timeout in seconds for completing API transactions with the Mist Cloud. Omit for default value of 10 seconds. Value of 0 results in infinite timeout.
+- `apitoken` (String, Sensitive) For API Token authentication, the Mist API Token.
+- `host` (String) URL of the Mist Cloud, e.g. `api.mist.com`.
+- `password` (String, Sensitive) For username/password authentication, the Mist Account password.
+- `proxy` (String) Requests use the configured proxy to reach the Mist Cloud.
+  The value may be either a complete URL or a `[username:password@]host[:port]`, in which case the `http` scheme is assumed. The schemes `http`, `https`, and `socks5` are supported.
+- `username` (String) For username/password authentication, the Mist Account username.
+### Environment Variables
+
+|   Varibale Name    | Provider attribute |  Type  |                                                                                                                  Description                                                                                                                   |
+|--------------------|--------------------|--------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `MIST_HOST`        | `host`             | String | URL of the Mist Cloud, e.g. `api.mist.com`. See above for the list of supported Clouds.                                                                                                                                                        |
+| `MIST_API_TOKEN`   | `apitoken`         | String | For API Token authentication, the Mist API Token.                                                                                                                                                                                              |
+| `MIST_USERNAME`    | `username`         | String | For username/password authentication, the Mist Account password.                                                                                                                                                                               |
+| `MIST_PASSWORD`    | `password`         | String | For username/password authentication, the Mist Account password.                                                                                                                                                                               |
+| `MIST_PROXY`       | `proxy`            | String | Requests use the configured proxy to reach the Mist Cloud. The value may be either a complete URL or a `[username:password@]host[:port]`, in which case the `http` scheme is assumed. The schemes `http`, `https`, and `socks5` are supported. |
+| `MIST_API_TIMEOUT` | `apiTimeout`      | Int    | Timeout in seconds for completing API transactions with the Mist Cloud. Omit for default value of 10 seconds. Value of 0 results in infinite timeout.                                                                                          |

--- a/patches/0002-Fix-spelling-in-docs-index.md.patch
+++ b/patches/0002-Fix-spelling-in-docs-index.md.patch
@@ -1,0 +1,19 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Ian Wahbe <me@iwahbe.com>
+Date: Fri, 24 Jan 2025 10:45:21 +0100
+Subject: [PATCH] Fix spelling in `docs/index.md`
+
+
+diff --git a/docs/index.md b/docs/index.md
+index 910ba9f..98d150e 100644
+--- a/docs/index.md
++++ b/docs/index.md
+@@ -8,7 +8,7 @@ description: |-
+ 
+ The Mist Provider allows Terraform to manage Juniper Mist Organizations.
+ 
+-It is mainly focusing on day 0 and day 1 operations (provisionning and delpyment) but will be completed over time.
++It is mainly focusing on day 0 and day 1 operations (provisioning and deployment) but will be completed over time.
+ 
+ Use the navigation tree to the left to read about the available resources and data sources.
+ 


### PR DESCRIPTION
This PR adds `registryDocs: true` to `.ci-mgmt.yaml`. I have run `make ci-mgmt && make build_registry_docs`. All other changes are generated.