### PR TITLE
Upgrade terraform-provider-mist to v0.3.2

### DIFF
--- a/provider/cmd/pulumi-resource-junipermist/schema.json
+++ b/provider/cmd/pulumi-resource-junipermist/schema.json
@@ -29357,7 +29357,8 @@
             "language": {
                 "nodejs": {
                     "requiredOutputs": [
-                        "configRevertTimer"
+                        "configRevertTimer",
+                        "useMxedgeProxy"
                     ]
                 }
             }
@@ -30090,6 +30091,8 @@
             "language": {
                 "nodejs": {
                     "requiredOutputs": [
+                        "adminSshkeys",
+                        "probeHosts",
                         "securityLogSourceInterface"
                     ]
                 }
@@ -30410,6 +30413,7 @@
             "language": {
                 "nodejs": {
                     "requiredOutputs": [
+                        "allowedVlanIds",
                         "enabled",
                         "honeypotEnabled",
                         "minDuration",
@@ -30846,6 +30850,7 @@
             "language": {
                 "nodejs": {
                     "requiredOutputs": [
+                        "emailNotifiers",
                         "enabled",
                         "threshold"
                     ]
@@ -45790,14 +45795,28 @@
                 }
             },
             "required": [
+                "analytic",
+                "autoUpgrade",
                 "blacklistUrl",
                 "configAutoRevert",
                 "enableUnii4",
+                "engagement",
+                "gatewayMgmt",
+                "led",
+                "occupancy",
                 "persistConfigOnDevice",
+                "rogue",
+                "rtsa",
                 "siteId",
                 "sshKeys",
+                "ssr",
+                "syntheticTest",
+                "uplinkPortConfig",
                 "watchedStationUrl",
-                "whitelistUrl"
+                "whitelistUrl",
+                "wids",
+                "wifi",
+                "zoneOccupancyAlert"
             ],
             "inputProperties": {
                 "analytic": {

--- a/sdk/dotnet/Site/Setting.cs
+++ b/sdk/dotnet/Site/Setting.cs
@@ -32,7 +32,7 @@ namespace Pulumi.JuniperMist.Site
     public partial class Setting : global::Pulumi.CustomResource
     {
         [Output("analytic")]
-        public Output<Outputs.SettingAnalytic?> Analytic { get; private set; } = null!;
+        public Output<Outputs.SettingAnalytic> Analytic { get; private set; } = null!;
 
         /// <summary>
         /// Enable threshold-based device down delivery for AP devices only. When configured it takes effect for AP devices and
@@ -45,7 +45,7 @@ namespace Pulumi.JuniperMist.Site
         /// Auto Upgrade Settings
         /// </summary>
         [Output("autoUpgrade")]
-        public Output<Outputs.SettingAutoUpgrade?> AutoUpgrade { get; private set; } = null!;
+        public Output<Outputs.SettingAutoUpgrade> AutoUpgrade { get; private set; } = null!;
 
         [Output("blacklistUrl")]
         public Output<string> BlacklistUrl { get; private set; } = null!;
@@ -89,13 +89,13 @@ namespace Pulumi.JuniperMist.Site
         /// ranges for the same day
         /// </summary>
         [Output("engagement")]
-        public Output<Outputs.SettingEngagement?> Engagement { get; private set; } = null!;
+        public Output<Outputs.SettingEngagement> Engagement { get; private set; } = null!;
 
         /// <summary>
         /// Gateway Site settings
         /// </summary>
         [Output("gatewayMgmt")]
-        public Output<Outputs.SettingGatewayMgmt?> GatewayMgmt { get; private set; } = null!;
+        public Output<Outputs.SettingGatewayMgmt> GatewayMgmt { get; private set; } = null!;
 
         /// <summary>
         /// Enable threshold-based device down delivery for Gateway devices only. When configured it takes effect for GW devices and
@@ -111,13 +111,13 @@ namespace Pulumi.JuniperMist.Site
         /// LED AP settings
         /// </summary>
         [Output("led")]
-        public Output<Outputs.SettingLed?> Led { get; private set; } = null!;
+        public Output<Outputs.SettingLed> Led { get; private set; } = null!;
 
         /// <summary>
         /// Occupancy Analytics settings
         /// </summary>
         [Output("occupancy")]
-        public Output<Outputs.SettingOccupancy?> Occupancy { get; private set; } = null!;
+        public Output<Outputs.SettingOccupancy> Occupancy { get; private set; } = null!;
 
         /// <summary>
         /// Whether to store the config on AP
@@ -148,13 +148,13 @@ namespace Pulumi.JuniperMist.Site
         /// Rogue site settings
         /// </summary>
         [Output("rogue")]
-        public Output<Outputs.SettingRogue?> Rogue { get; private set; } = null!;
+        public Output<Outputs.SettingRogue> Rogue { get; private set; } = null!;
 
         /// <summary>
         /// Managed mobility
         /// </summary>
         [Output("rtsa")]
-        public Output<Outputs.SettingRtsa?> Rtsa { get; private set; } = null!;
+        public Output<Outputs.SettingRtsa> Rtsa { get; private set; } = null!;
 
         /// <summary>
         /// Set of heuristic rules will be enabled when marvis subscription is not available. It triggers when, in a Z minute
@@ -180,7 +180,7 @@ namespace Pulumi.JuniperMist.Site
         public Output<ImmutableArray<string>> SshKeys { get; private set; } = null!;
 
         [Output("ssr")]
-        public Output<Outputs.SettingSsr?> Ssr { get; private set; } = null!;
+        public Output<Outputs.SettingSsr> Ssr { get; private set; } = null!;
 
         /// <summary>
         /// Enable threshold-based device down delivery for Switch devices only. When configured it takes effect for SW devices and
@@ -190,7 +190,7 @@ namespace Pulumi.JuniperMist.Site
         public Output<int?> SwitchUpdownThreshold { get; private set; } = null!;
 
         [Output("syntheticTest")]
-        public Output<Outputs.SettingSyntheticTest?> SyntheticTest { get; private set; } = null!;
+        public Output<Outputs.SettingSyntheticTest> SyntheticTest { get; private set; } = null!;
 
         /// <summary>
         /// Whether to track anonymous BLE assets (requires ‘track_asset’ enabled)
@@ -202,7 +202,7 @@ namespace Pulumi.JuniperMist.Site
         /// AP Uplink port configuration
         /// </summary>
         [Output("uplinkPortConfig")]
-        public Output<Outputs.SettingUplinkPortConfig?> UplinkPortConfig { get; private set; } = null!;
+        public Output<Outputs.SettingUplinkPortConfig> UplinkPortConfig { get; private set; } = null!;
 
         /// <summary>
         /// Dictionary of name-&gt;value, the vars can then be used in Wlans. This can overwrite those from Site Vars
@@ -232,13 +232,13 @@ namespace Pulumi.JuniperMist.Site
         /// WIDS site settings
         /// </summary>
         [Output("wids")]
-        public Output<Outputs.SettingWids?> Wids { get; private set; } = null!;
+        public Output<Outputs.SettingWids> Wids { get; private set; } = null!;
 
         /// <summary>
         /// Wi-Fi site settings
         /// </summary>
         [Output("wifi")]
-        public Output<Outputs.SettingWifi?> Wifi { get; private set; } = null!;
+        public Output<Outputs.SettingWifi> Wifi { get; private set; } = null!;
 
         [Output("wiredVna")]
         public Output<Outputs.SettingWiredVna?> WiredVna { get; private set; } = null!;
@@ -247,7 +247,7 @@ namespace Pulumi.JuniperMist.Site
         /// Zone Occupancy alert site settings
         /// </summary>
         [Output("zoneOccupancyAlert")]
-        public Output<Outputs.SettingZoneOccupancyAlert?> ZoneOccupancyAlert { get; private set; } = null!;
+        public Output<Outputs.SettingZoneOccupancyAlert> ZoneOccupancyAlert { get; private set; } = null!;
 
 
         /// <summary>

--- a/sdk/go/junipermist/site/setting.go
+++ b/sdk/go/junipermist/site/setting.go
@@ -32,13 +32,13 @@ import (
 type Setting struct {
 	pulumi.CustomResourceState
 
-	Analytic SettingAnalyticPtrOutput `pulumi:"analytic"`
+	Analytic SettingAnalyticOutput `pulumi:"analytic"`
 	// Enable threshold-based device down delivery for AP devices only. When configured it takes effect for AP devices and
 	// `deviceUpdownThreshold` is ignored.
 	ApUpdownThreshold pulumi.IntPtrOutput `pulumi:"apUpdownThreshold"`
 	// Auto Upgrade Settings
-	AutoUpgrade  SettingAutoUpgradePtrOutput `pulumi:"autoUpgrade"`
-	BlacklistUrl pulumi.StringOutput         `pulumi:"blacklistUrl"`
+	AutoUpgrade  SettingAutoUpgradeOutput `pulumi:"autoUpgrade"`
+	BlacklistUrl pulumi.StringOutput      `pulumi:"blacklistUrl"`
 	// BLE AP settings
 	BleConfig SettingBleConfigPtrOutput `pulumi:"bleConfig"`
 	// Whether to enable ap auto config revert
@@ -53,17 +53,17 @@ type Setting struct {
 	EnableUnii4           pulumi.BoolOutput   `pulumi:"enableUnii4"`
 	// **Note**: if hours does not exist, it's treated as everyday of the week, 00:00-23:59. Currently, we don't allow multiple
 	// ranges for the same day
-	Engagement SettingEngagementPtrOutput `pulumi:"engagement"`
+	Engagement SettingEngagementOutput `pulumi:"engagement"`
 	// Gateway Site settings
-	GatewayMgmt SettingGatewayMgmtPtrOutput `pulumi:"gatewayMgmt"`
+	GatewayMgmt SettingGatewayMgmtOutput `pulumi:"gatewayMgmt"`
 	// Enable threshold-based device down delivery for Gateway devices only. When configured it takes effect for GW devices and
 	// `deviceUpdownThreshold` is ignored.
 	GatewayUpdownThreshold pulumi.IntPtrOutput        `pulumi:"gatewayUpdownThreshold"`
 	JuniperSrx             SettingJuniperSrxPtrOutput `pulumi:"juniperSrx"`
 	// LED AP settings
-	Led SettingLedPtrOutput `pulumi:"led"`
+	Led SettingLedOutput `pulumi:"led"`
 	// Occupancy Analytics settings
-	Occupancy SettingOccupancyPtrOutput `pulumi:"occupancy"`
+	Occupancy SettingOccupancyOutput `pulumi:"occupancy"`
 	// Whether to store the config on AP
 	PersistConfigOnDevice pulumi.BoolOutput `pulumi:"persistConfigOnDevice"`
 	// Proxy Configuration to talk to Mist
@@ -74,9 +74,9 @@ type Setting struct {
 	// serial number, battery %, temperature, humidity)
 	ReportGatt pulumi.BoolPtrOutput `pulumi:"reportGatt"`
 	// Rogue site settings
-	Rogue SettingRoguePtrOutput `pulumi:"rogue"`
+	Rogue SettingRogueOutput `pulumi:"rogue"`
 	// Managed mobility
-	Rtsa SettingRtsaPtrOutput `pulumi:"rtsa"`
+	Rtsa SettingRtsaOutput `pulumi:"rtsa"`
 	// Set of heuristic rules will be enabled when marvis subscription is not available. It triggers when, in a Z minute
 	// window, there are more than Y distinct client encountering over X failures
 	SimpleAlert SettingSimpleAlertPtrOutput `pulumi:"simpleAlert"`
@@ -86,15 +86,15 @@ type Setting struct {
 	// When limitSshAccess = true in Org Setting, list of SSH public keys provided by Mist Support to install onto APs (see
 	// Org:Setting)
 	SshKeys pulumi.StringArrayOutput `pulumi:"sshKeys"`
-	Ssr     SettingSsrPtrOutput      `pulumi:"ssr"`
+	Ssr     SettingSsrOutput         `pulumi:"ssr"`
 	// Enable threshold-based device down delivery for Switch devices only. When configured it takes effect for SW devices and
 	// `deviceUpdownThreshold` is ignored.
-	SwitchUpdownThreshold pulumi.IntPtrOutput           `pulumi:"switchUpdownThreshold"`
-	SyntheticTest         SettingSyntheticTestPtrOutput `pulumi:"syntheticTest"`
+	SwitchUpdownThreshold pulumi.IntPtrOutput        `pulumi:"switchUpdownThreshold"`
+	SyntheticTest         SettingSyntheticTestOutput `pulumi:"syntheticTest"`
 	// Whether to track anonymous BLE assets (requires ‘track_asset’ enabled)
 	TrackAnonymousDevices pulumi.BoolPtrOutput `pulumi:"trackAnonymousDevices"`
 	// AP Uplink port configuration
-	UplinkPortConfig SettingUplinkPortConfigPtrOutput `pulumi:"uplinkPortConfig"`
+	UplinkPortConfig SettingUplinkPortConfigOutput `pulumi:"uplinkPortConfig"`
 	// Dictionary of name->value, the vars can then be used in Wlans. This can overwrite those from Site Vars
 	Vars pulumi.StringMapOutput `pulumi:"vars"`
 	Vna  SettingVnaPtrOutput    `pulumi:"vna"`
@@ -104,12 +104,12 @@ type Setting struct {
 	WatchedStationUrl pulumi.StringOutput        `pulumi:"watchedStationUrl"`
 	WhitelistUrl      pulumi.StringOutput        `pulumi:"whitelistUrl"`
 	// WIDS site settings
-	Wids SettingWidsPtrOutput `pulumi:"wids"`
+	Wids SettingWidsOutput `pulumi:"wids"`
 	// Wi-Fi site settings
-	Wifi     SettingWifiPtrOutput     `pulumi:"wifi"`
+	Wifi     SettingWifiOutput        `pulumi:"wifi"`
 	WiredVna SettingWiredVnaPtrOutput `pulumi:"wiredVna"`
 	// Zone Occupancy alert site settings
-	ZoneOccupancyAlert SettingZoneOccupancyAlertPtrOutput `pulumi:"zoneOccupancyAlert"`
+	ZoneOccupancyAlert SettingZoneOccupancyAlertOutput `pulumi:"zoneOccupancyAlert"`
 }
 
 // NewSetting registers a new resource with the given unique name, arguments, and options.
@@ -554,8 +554,8 @@ func (o SettingOutput) ToSettingOutputWithContext(ctx context.Context) SettingOu
 	return o
 }
 
-func (o SettingOutput) Analytic() SettingAnalyticPtrOutput {
-	return o.ApplyT(func(v *Setting) SettingAnalyticPtrOutput { return v.Analytic }).(SettingAnalyticPtrOutput)
+func (o SettingOutput) Analytic() SettingAnalyticOutput {
+	return o.ApplyT(func(v *Setting) SettingAnalyticOutput { return v.Analytic }).(SettingAnalyticOutput)
 }
 
 // Enable threshold-based device down delivery for AP devices only. When configured it takes effect for AP devices and
@@ -565,8 +565,8 @@ func (o SettingOutput) ApUpdownThreshold() pulumi.IntPtrOutput {
 }
 
 // Auto Upgrade Settings
-func (o SettingOutput) AutoUpgrade() SettingAutoUpgradePtrOutput {
-	return o.ApplyT(func(v *Setting) SettingAutoUpgradePtrOutput { return v.AutoUpgrade }).(SettingAutoUpgradePtrOutput)
+func (o SettingOutput) AutoUpgrade() SettingAutoUpgradeOutput {
+	return o.ApplyT(func(v *Setting) SettingAutoUpgradeOutput { return v.AutoUpgrade }).(SettingAutoUpgradeOutput)
 }
 
 func (o SettingOutput) BlacklistUrl() pulumi.StringOutput {
@@ -605,13 +605,13 @@ func (o SettingOutput) EnableUnii4() pulumi.BoolOutput {
 
 // **Note**: if hours does not exist, it's treated as everyday of the week, 00:00-23:59. Currently, we don't allow multiple
 // ranges for the same day
-func (o SettingOutput) Engagement() SettingEngagementPtrOutput {
-	return o.ApplyT(func(v *Setting) SettingEngagementPtrOutput { return v.Engagement }).(SettingEngagementPtrOutput)
+func (o SettingOutput) Engagement() SettingEngagementOutput {
+	return o.ApplyT(func(v *Setting) SettingEngagementOutput { return v.Engagement }).(SettingEngagementOutput)
 }
 
 // Gateway Site settings
-func (o SettingOutput) GatewayMgmt() SettingGatewayMgmtPtrOutput {
-	return o.ApplyT(func(v *Setting) SettingGatewayMgmtPtrOutput { return v.GatewayMgmt }).(SettingGatewayMgmtPtrOutput)
+func (o SettingOutput) GatewayMgmt() SettingGatewayMgmtOutput {
+	return o.ApplyT(func(v *Setting) SettingGatewayMgmtOutput { return v.GatewayMgmt }).(SettingGatewayMgmtOutput)
 }
 
 // Enable threshold-based device down delivery for Gateway devices only. When configured it takes effect for GW devices and
@@ -625,13 +625,13 @@ func (o SettingOutput) JuniperSrx() SettingJuniperSrxPtrOutput {
 }
 
 // LED AP settings
-func (o SettingOutput) Led() SettingLedPtrOutput {
-	return o.ApplyT(func(v *Setting) SettingLedPtrOutput { return v.Led }).(SettingLedPtrOutput)
+func (o SettingOutput) Led() SettingLedOutput {
+	return o.ApplyT(func(v *Setting) SettingLedOutput { return v.Led }).(SettingLedOutput)
 }
 
 // Occupancy Analytics settings
-func (o SettingOutput) Occupancy() SettingOccupancyPtrOutput {
-	return o.ApplyT(func(v *Setting) SettingOccupancyPtrOutput { return v.Occupancy }).(SettingOccupancyPtrOutput)
+func (o SettingOutput) Occupancy() SettingOccupancyOutput {
+	return o.ApplyT(func(v *Setting) SettingOccupancyOutput { return v.Occupancy }).(SettingOccupancyOutput)
 }
 
 // Whether to store the config on AP
@@ -656,13 +656,13 @@ func (o SettingOutput) ReportGatt() pulumi.BoolPtrOutput {
 }
 
 // Rogue site settings
-func (o SettingOutput) Rogue() SettingRoguePtrOutput {
-	return o.ApplyT(func(v *Setting) SettingRoguePtrOutput { return v.Rogue }).(SettingRoguePtrOutput)
+func (o SettingOutput) Rogue() SettingRogueOutput {
+	return o.ApplyT(func(v *Setting) SettingRogueOutput { return v.Rogue }).(SettingRogueOutput)
 }
 
 // Managed mobility
-func (o SettingOutput) Rtsa() SettingRtsaPtrOutput {
-	return o.ApplyT(func(v *Setting) SettingRtsaPtrOutput { return v.Rtsa }).(SettingRtsaPtrOutput)
+func (o SettingOutput) Rtsa() SettingRtsaOutput {
+	return o.ApplyT(func(v *Setting) SettingRtsaOutput { return v.Rtsa }).(SettingRtsaOutput)
 }
 
 // Set of heuristic rules will be enabled when marvis subscription is not available. It triggers when, in a Z minute
@@ -689,8 +689,8 @@ func (o SettingOutput) SshKeys() pulumi.StringArrayOutput {
 	return o.ApplyT(func(v *Setting) pulumi.StringArrayOutput { return v.SshKeys }).(pulumi.StringArrayOutput)
 }
 
-func (o SettingOutput) Ssr() SettingSsrPtrOutput {
-	return o.ApplyT(func(v *Setting) SettingSsrPtrOutput { return v.Ssr }).(SettingSsrPtrOutput)
+func (o SettingOutput) Ssr() SettingSsrOutput {
+	return o.ApplyT(func(v *Setting) SettingSsrOutput { return v.Ssr }).(SettingSsrOutput)
 }
 
 // Enable threshold-based device down delivery for Switch devices only. When configured it takes effect for SW devices and
@@ -699,8 +699,8 @@ func (o SettingOutput) SwitchUpdownThreshold() pulumi.IntPtrOutput {
 	return o.ApplyT(func(v *Setting) pulumi.IntPtrOutput { return v.SwitchUpdownThreshold }).(pulumi.IntPtrOutput)
 }
 
-func (o SettingOutput) SyntheticTest() SettingSyntheticTestPtrOutput {
-	return o.ApplyT(func(v *Setting) SettingSyntheticTestPtrOutput { return v.SyntheticTest }).(SettingSyntheticTestPtrOutput)
+func (o SettingOutput) SyntheticTest() SettingSyntheticTestOutput {
+	return o.ApplyT(func(v *Setting) SettingSyntheticTestOutput { return v.SyntheticTest }).(SettingSyntheticTestOutput)
 }
 
 // Whether to track anonymous BLE assets (requires ‘track_asset’ enabled)
@@ -709,8 +709,8 @@ func (o SettingOutput) TrackAnonymousDevices() pulumi.BoolPtrOutput {
 }
 
 // AP Uplink port configuration
-func (o SettingOutput) UplinkPortConfig() SettingUplinkPortConfigPtrOutput {
-	return o.ApplyT(func(v *Setting) SettingUplinkPortConfigPtrOutput { return v.UplinkPortConfig }).(SettingUplinkPortConfigPtrOutput)
+func (o SettingOutput) UplinkPortConfig() SettingUplinkPortConfigOutput {
+	return o.ApplyT(func(v *Setting) SettingUplinkPortConfigOutput { return v.UplinkPortConfig }).(SettingUplinkPortConfigOutput)
 }
 
 // Dictionary of name->value, the vars can then be used in Wlans. This can overwrite those from Site Vars
@@ -740,13 +740,13 @@ func (o SettingOutput) WhitelistUrl() pulumi.StringOutput {
 }
 
 // WIDS site settings
-func (o SettingOutput) Wids() SettingWidsPtrOutput {
-	return o.ApplyT(func(v *Setting) SettingWidsPtrOutput { return v.Wids }).(SettingWidsPtrOutput)
+func (o SettingOutput) Wids() SettingWidsOutput {
+	return o.ApplyT(func(v *Setting) SettingWidsOutput { return v.Wids }).(SettingWidsOutput)
 }
 
 // Wi-Fi site settings
-func (o SettingOutput) Wifi() SettingWifiPtrOutput {
-	return o.ApplyT(func(v *Setting) SettingWifiPtrOutput { return v.Wifi }).(SettingWifiPtrOutput)
+func (o SettingOutput) Wifi() SettingWifiOutput {
+	return o.ApplyT(func(v *Setting) SettingWifiOutput { return v.Wifi }).(SettingWifiOutput)
 }
 
 func (o SettingOutput) WiredVna() SettingWiredVnaPtrOutput {
@@ -754,8 +754,8 @@ func (o SettingOutput) WiredVna() SettingWiredVnaPtrOutput {
 }
 
 // Zone Occupancy alert site settings
-func (o SettingOutput) ZoneOccupancyAlert() SettingZoneOccupancyAlertPtrOutput {
-	return o.ApplyT(func(v *Setting) SettingZoneOccupancyAlertPtrOutput { return v.ZoneOccupancyAlert }).(SettingZoneOccupancyAlertPtrOutput)
+func (o SettingOutput) ZoneOccupancyAlert() SettingZoneOccupancyAlertOutput {
+	return o.ApplyT(func(v *Setting) SettingZoneOccupancyAlertOutput { return v.ZoneOccupancyAlert }).(SettingZoneOccupancyAlertOutput)
 }
 
 type SettingArrayOutput struct{ *pulumi.OutputState }

--- a/sdk/java/src/main/java/com/pulumi/junipermist/site/Setting.java
+++ b/sdk/java/src/main/java/com/pulumi/junipermist/site/Setting.java
@@ -72,10 +72,10 @@ import javax.annotation.Nullable;
 @ResourceType(type="junipermist:site/setting:Setting")
 public class Setting extends com.pulumi.resources.CustomResource {
     @Export(name="analytic", refs={SettingAnalytic.class}, tree="[0]")
-    private Output</* @Nullable */ SettingAnalytic> analytic;
+    private Output<SettingAnalytic> analytic;
 
-    public Output<Optional<SettingAnalytic>> analytic() {
-        return Codegen.optional(this.analytic);
+    public Output<SettingAnalytic> analytic() {
+        return this.analytic;
     }
     /**
      * Enable threshold-based device down delivery for AP devices only. When configured it takes effect for AP devices and
@@ -98,14 +98,14 @@ public class Setting extends com.pulumi.resources.CustomResource {
      * 
      */
     @Export(name="autoUpgrade", refs={SettingAutoUpgrade.class}, tree="[0]")
-    private Output</* @Nullable */ SettingAutoUpgrade> autoUpgrade;
+    private Output<SettingAutoUpgrade> autoUpgrade;
 
     /**
      * @return Auto Upgrade Settings
      * 
      */
-    public Output<Optional<SettingAutoUpgrade>> autoUpgrade() {
-        return Codegen.optional(this.autoUpgrade);
+    public Output<SettingAutoUpgrade> autoUpgrade() {
+        return this.autoUpgrade;
     }
     @Export(name="blacklistUrl", refs={String.class}, tree="[0]")
     private Output<String> blacklistUrl;
@@ -197,29 +197,29 @@ public class Setting extends com.pulumi.resources.CustomResource {
      * 
      */
     @Export(name="engagement", refs={SettingEngagement.class}, tree="[0]")
-    private Output</* @Nullable */ SettingEngagement> engagement;
+    private Output<SettingEngagement> engagement;
 
     /**
      * @return **Note**: if hours does not exist, it&#39;s treated as everyday of the week, 00:00-23:59. Currently, we don&#39;t allow multiple
      * ranges for the same day
      * 
      */
-    public Output<Optional<SettingEngagement>> engagement() {
-        return Codegen.optional(this.engagement);
+    public Output<SettingEngagement> engagement() {
+        return this.engagement;
     }
     /**
      * Gateway Site settings
      * 
      */
     @Export(name="gatewayMgmt", refs={SettingGatewayMgmt.class}, tree="[0]")
-    private Output</* @Nullable */ SettingGatewayMgmt> gatewayMgmt;
+    private Output<SettingGatewayMgmt> gatewayMgmt;
 
     /**
      * @return Gateway Site settings
      * 
      */
-    public Output<Optional<SettingGatewayMgmt>> gatewayMgmt() {
-        return Codegen.optional(this.gatewayMgmt);
+    public Output<SettingGatewayMgmt> gatewayMgmt() {
+        return this.gatewayMgmt;
     }
     /**
      * Enable threshold-based device down delivery for Gateway devices only. When configured it takes effect for GW devices and
@@ -248,28 +248,28 @@ public class Setting extends com.pulumi.resources.CustomResource {
      * 
      */
     @Export(name="led", refs={SettingLed.class}, tree="[0]")
-    private Output</* @Nullable */ SettingLed> led;
+    private Output<SettingLed> led;
 
     /**
      * @return LED AP settings
      * 
      */
-    public Output<Optional<SettingLed>> led() {
-        return Codegen.optional(this.led);
+    public Output<SettingLed> led() {
+        return this.led;
     }
     /**
      * Occupancy Analytics settings
      * 
      */
     @Export(name="occupancy", refs={SettingOccupancy.class}, tree="[0]")
-    private Output</* @Nullable */ SettingOccupancy> occupancy;
+    private Output<SettingOccupancy> occupancy;
 
     /**
      * @return Occupancy Analytics settings
      * 
      */
-    public Output<Optional<SettingOccupancy>> occupancy() {
-        return Codegen.optional(this.occupancy);
+    public Output<SettingOccupancy> occupancy() {
+        return this.occupancy;
     }
     /**
      * Whether to store the config on AP
@@ -334,28 +334,28 @@ public class Setting extends com.pulumi.resources.CustomResource {
      * 
      */
     @Export(name="rogue", refs={SettingRogue.class}, tree="[0]")
-    private Output</* @Nullable */ SettingRogue> rogue;
+    private Output<SettingRogue> rogue;
 
     /**
      * @return Rogue site settings
      * 
      */
-    public Output<Optional<SettingRogue>> rogue() {
-        return Codegen.optional(this.rogue);
+    public Output<SettingRogue> rogue() {
+        return this.rogue;
     }
     /**
      * Managed mobility
      * 
      */
     @Export(name="rtsa", refs={SettingRtsa.class}, tree="[0]")
-    private Output</* @Nullable */ SettingRtsa> rtsa;
+    private Output<SettingRtsa> rtsa;
 
     /**
      * @return Managed mobility
      * 
      */
-    public Output<Optional<SettingRtsa>> rtsa() {
-        return Codegen.optional(this.rtsa);
+    public Output<SettingRtsa> rtsa() {
+        return this.rtsa;
     }
     /**
      * Set of heuristic rules will be enabled when marvis subscription is not available. It triggers when, in a Z minute
@@ -408,10 +408,10 @@ public class Setting extends com.pulumi.resources.CustomResource {
         return this.sshKeys;
     }
     @Export(name="ssr", refs={SettingSsr.class}, tree="[0]")
-    private Output</* @Nullable */ SettingSsr> ssr;
+    private Output<SettingSsr> ssr;
 
-    public Output<Optional<SettingSsr>> ssr() {
-        return Codegen.optional(this.ssr);
+    public Output<SettingSsr> ssr() {
+        return this.ssr;
     }
     /**
      * Enable threshold-based device down delivery for Switch devices only. When configured it takes effect for SW devices and
@@ -430,10 +430,10 @@ public class Setting extends com.pulumi.resources.CustomResource {
         return Codegen.optional(this.switchUpdownThreshold);
     }
     @Export(name="syntheticTest", refs={SettingSyntheticTest.class}, tree="[0]")
-    private Output</* @Nullable */ SettingSyntheticTest> syntheticTest;
+    private Output<SettingSyntheticTest> syntheticTest;
 
-    public Output<Optional<SettingSyntheticTest>> syntheticTest() {
-        return Codegen.optional(this.syntheticTest);
+    public Output<SettingSyntheticTest> syntheticTest() {
+        return this.syntheticTest;
     }
     /**
      * Whether to track anonymous BLE assets (requires ‘track_asset’ enabled)
@@ -454,14 +454,14 @@ public class Setting extends com.pulumi.resources.CustomResource {
      * 
      */
     @Export(name="uplinkPortConfig", refs={SettingUplinkPortConfig.class}, tree="[0]")
-    private Output</* @Nullable */ SettingUplinkPortConfig> uplinkPortConfig;
+    private Output<SettingUplinkPortConfig> uplinkPortConfig;
 
     /**
      * @return AP Uplink port configuration
      * 
      */
-    public Output<Optional<SettingUplinkPortConfig>> uplinkPortConfig() {
-        return Codegen.optional(this.uplinkPortConfig);
+    public Output<SettingUplinkPortConfig> uplinkPortConfig() {
+        return this.uplinkPortConfig;
     }
     /**
      * Dictionary of name-&gt;value, the vars can then be used in Wlans. This can overwrite those from Site Vars
@@ -520,28 +520,28 @@ public class Setting extends com.pulumi.resources.CustomResource {
      * 
      */
     @Export(name="wids", refs={SettingWids.class}, tree="[0]")
-    private Output</* @Nullable */ SettingWids> wids;
+    private Output<SettingWids> wids;
 
     /**
      * @return WIDS site settings
      * 
      */
-    public Output<Optional<SettingWids>> wids() {
-        return Codegen.optional(this.wids);
+    public Output<SettingWids> wids() {
+        return this.wids;
     }
     /**
      * Wi-Fi site settings
      * 
      */
     @Export(name="wifi", refs={SettingWifi.class}, tree="[0]")
-    private Output</* @Nullable */ SettingWifi> wifi;
+    private Output<SettingWifi> wifi;
 
     /**
      * @return Wi-Fi site settings
      * 
      */
-    public Output<Optional<SettingWifi>> wifi() {
-        return Codegen.optional(this.wifi);
+    public Output<SettingWifi> wifi() {
+        return this.wifi;
     }
     @Export(name="wiredVna", refs={SettingWiredVna.class}, tree="[0]")
     private Output</* @Nullable */ SettingWiredVna> wiredVna;
@@ -554,14 +554,14 @@ public class Setting extends com.pulumi.resources.CustomResource {
      * 
      */
     @Export(name="zoneOccupancyAlert", refs={SettingZoneOccupancyAlert.class}, tree="[0]")
-    private Output</* @Nullable */ SettingZoneOccupancyAlert> zoneOccupancyAlert;
+    private Output<SettingZoneOccupancyAlert> zoneOccupancyAlert;
 
     /**
      * @return Zone Occupancy alert site settings
      * 
      */
-    public Output<Optional<SettingZoneOccupancyAlert>> zoneOccupancyAlert() {
-        return Codegen.optional(this.zoneOccupancyAlert);
+    public Output<SettingZoneOccupancyAlert> zoneOccupancyAlert() {
+        return this.zoneOccupancyAlert;
     }
 
     /**

--- a/sdk/nodejs/site/setting.ts
+++ b/sdk/nodejs/site/setting.ts
@@ -53,7 +53,7 @@ export class Setting extends pulumi.CustomResource {
         return obj['__pulumiType'] === Setting.__pulumiType;
     }
 
-    public readonly analytic!: pulumi.Output<outputs.site.SettingAnalytic | undefined>;
+    public readonly analytic!: pulumi.Output<outputs.site.SettingAnalytic>;
     /**
      * Enable threshold-based device down delivery for AP devices only. When configured it takes effect for AP devices and
      * `deviceUpdownThreshold` is ignored.
@@ -62,7 +62,7 @@ export class Setting extends pulumi.CustomResource {
     /**
      * Auto Upgrade Settings
      */
-    public readonly autoUpgrade!: pulumi.Output<outputs.site.SettingAutoUpgrade | undefined>;
+    public readonly autoUpgrade!: pulumi.Output<outputs.site.SettingAutoUpgrade>;
     public /*out*/ readonly blacklistUrl!: pulumi.Output<string>;
     /**
      * BLE AP settings
@@ -90,11 +90,11 @@ export class Setting extends pulumi.CustomResource {
      * **Note**: if hours does not exist, it's treated as everyday of the week, 00:00-23:59. Currently, we don't allow multiple
      * ranges for the same day
      */
-    public readonly engagement!: pulumi.Output<outputs.site.SettingEngagement | undefined>;
+    public readonly engagement!: pulumi.Output<outputs.site.SettingEngagement>;
     /**
      * Gateway Site settings
      */
-    public readonly gatewayMgmt!: pulumi.Output<outputs.site.SettingGatewayMgmt | undefined>;
+    public readonly gatewayMgmt!: pulumi.Output<outputs.site.SettingGatewayMgmt>;
     /**
      * Enable threshold-based device down delivery for Gateway devices only. When configured it takes effect for GW devices and
      * `deviceUpdownThreshold` is ignored.
@@ -104,11 +104,11 @@ export class Setting extends pulumi.CustomResource {
     /**
      * LED AP settings
      */
-    public readonly led!: pulumi.Output<outputs.site.SettingLed | undefined>;
+    public readonly led!: pulumi.Output<outputs.site.SettingLed>;
     /**
      * Occupancy Analytics settings
      */
-    public readonly occupancy!: pulumi.Output<outputs.site.SettingOccupancy | undefined>;
+    public readonly occupancy!: pulumi.Output<outputs.site.SettingOccupancy>;
     /**
      * Whether to store the config on AP
      */
@@ -129,11 +129,11 @@ export class Setting extends pulumi.CustomResource {
     /**
      * Rogue site settings
      */
-    public readonly rogue!: pulumi.Output<outputs.site.SettingRogue | undefined>;
+    public readonly rogue!: pulumi.Output<outputs.site.SettingRogue>;
     /**
      * Managed mobility
      */
-    public readonly rtsa!: pulumi.Output<outputs.site.SettingRtsa | undefined>;
+    public readonly rtsa!: pulumi.Output<outputs.site.SettingRtsa>;
     /**
      * Set of heuristic rules will be enabled when marvis subscription is not available. It triggers when, in a Z minute
      * window, there are more than Y distinct client encountering over X failures
@@ -147,13 +147,13 @@ export class Setting extends pulumi.CustomResource {
      * Org:Setting)
      */
     public readonly sshKeys!: pulumi.Output<string[]>;
-    public readonly ssr!: pulumi.Output<outputs.site.SettingSsr | undefined>;
+    public readonly ssr!: pulumi.Output<outputs.site.SettingSsr>;
     /**
      * Enable threshold-based device down delivery for Switch devices only. When configured it takes effect for SW devices and
      * `deviceUpdownThreshold` is ignored.
      */
     public readonly switchUpdownThreshold!: pulumi.Output<number | undefined>;
-    public readonly syntheticTest!: pulumi.Output<outputs.site.SettingSyntheticTest | undefined>;
+    public readonly syntheticTest!: pulumi.Output<outputs.site.SettingSyntheticTest>;
     /**
      * Whether to track anonymous BLE assets (requires ‘track_asset’ enabled)
      */
@@ -161,7 +161,7 @@ export class Setting extends pulumi.CustomResource {
     /**
      * AP Uplink port configuration
      */
-    public readonly uplinkPortConfig!: pulumi.Output<outputs.site.SettingUplinkPortConfig | undefined>;
+    public readonly uplinkPortConfig!: pulumi.Output<outputs.site.SettingUplinkPortConfig>;
     /**
      * Dictionary of name->value, the vars can then be used in Wlans. This can overwrite those from Site Vars
      */
@@ -177,16 +177,16 @@ export class Setting extends pulumi.CustomResource {
     /**
      * WIDS site settings
      */
-    public readonly wids!: pulumi.Output<outputs.site.SettingWids | undefined>;
+    public readonly wids!: pulumi.Output<outputs.site.SettingWids>;
     /**
      * Wi-Fi site settings
      */
-    public readonly wifi!: pulumi.Output<outputs.site.SettingWifi | undefined>;
+    public readonly wifi!: pulumi.Output<outputs.site.SettingWifi>;
     public readonly wiredVna!: pulumi.Output<outputs.site.SettingWiredVna | undefined>;
     /**
      * Zone Occupancy alert site settings
      */
-    public readonly zoneOccupancyAlert!: pulumi.Output<outputs.site.SettingZoneOccupancyAlert | undefined>;
+    public readonly zoneOccupancyAlert!: pulumi.Output<outputs.site.SettingZoneOccupancyAlert>;
 
     /**
      * Create a Setting resource with the given unique name, arguments, and options.

--- a/sdk/nodejs/types/output.ts
+++ b/sdk/nodejs/types/output.ts
@@ -17692,7 +17692,7 @@ Please update your configurations.
         /**
          * To use mxedge as proxy
          */
-        useMxedgeProxy?: boolean;
+        useMxedgeProxy: boolean;
     }
 
     export interface NetworktemplateSwitchMgmtLocalAccounts {
@@ -18084,7 +18084,7 @@ Please update your configurations.
         /**
          * For SSR only, as direct root access is not allowed
          */
-        adminSshkeys?: string[];
+        adminSshkeys: string[];
         appProbing?: outputs.site.SettingGatewayMgmtAppProbing;
         /**
          * Consumes uplink bandwidth, requires WA license
@@ -18108,7 +18108,7 @@ Please update your configurations.
          */
         disableUsb?: boolean;
         fipsEnabled?: boolean;
-        probeHosts?: string[];
+        probeHosts: string[];
         /**
          * Restrict inbound-traffic to host
          * when enabled, all traffic that is not essential to our operation will be dropped 
@@ -18245,7 +18245,7 @@ Please update your configurations.
         /**
          * list of VLAN IDs on which rogue APs are ignored
          */
-        allowedVlanIds?: number[];
+        allowedVlanIds: number[];
         /**
          * Whether rogue detection is enabled
          */
@@ -18463,7 +18463,7 @@ Please update your configurations.
         /**
          * List of email addresses to send email notifications when the alert threshold is reached
          */
-        emailNotifiers?: string[];
+        emailNotifiers: string[];
         /**
          * Indicate whether zone occupancy alert is enabled for the site
          */

--- a/sdk/python/pulumi_juniper_mist/site/setting.py
+++ b/sdk/python/pulumi_juniper_mist/site/setting.py
@@ -1643,7 +1643,7 @@ class Setting(pulumi.CustomResource):
 
     @property
     @pulumi.getter
-    def analytic(self) -> pulumi.Output[Optional['outputs.SettingAnalytic']]:
+    def analytic(self) -> pulumi.Output['outputs.SettingAnalytic']:
         return pulumi.get(self, "analytic")
 
     @property
@@ -1657,7 +1657,7 @@ class Setting(pulumi.CustomResource):
 
     @property
     @pulumi.getter(name="autoUpgrade")
-    def auto_upgrade(self) -> pulumi.Output[Optional['outputs.SettingAutoUpgrade']]:
+    def auto_upgrade(self) -> pulumi.Output['outputs.SettingAutoUpgrade']:
         """
         Auto Upgrade Settings
         """
@@ -1716,7 +1716,7 @@ class Setting(pulumi.CustomResource):
 
     @property
     @pulumi.getter
-    def engagement(self) -> pulumi.Output[Optional['outputs.SettingEngagement']]:
+    def engagement(self) -> pulumi.Output['outputs.SettingEngagement']:
         """
         **Note**: if hours does not exist, it's treated as everyday of the week, 00:00-23:59. Currently, we don't allow multiple
         ranges for the same day
@@ -1725,7 +1725,7 @@ class Setting(pulumi.CustomResource):
 
     @property
     @pulumi.getter(name="gatewayMgmt")
-    def gateway_mgmt(self) -> pulumi.Output[Optional['outputs.SettingGatewayMgmt']]:
+    def gateway_mgmt(self) -> pulumi.Output['outputs.SettingGatewayMgmt']:
         """
         Gateway Site settings
         """
@@ -1747,7 +1747,7 @@ class Setting(pulumi.CustomResource):
 
     @property
     @pulumi.getter
-    def led(self) -> pulumi.Output[Optional['outputs.SettingLed']]:
+    def led(self) -> pulumi.Output['outputs.SettingLed']:
         """
         LED AP settings
         """
@@ -1755,7 +1755,7 @@ class Setting(pulumi.CustomResource):
 
     @property
     @pulumi.getter
-    def occupancy(self) -> pulumi.Output[Optional['outputs.SettingOccupancy']]:
+    def occupancy(self) -> pulumi.Output['outputs.SettingOccupancy']:
         """
         Occupancy Analytics settings
         """
@@ -1796,7 +1796,7 @@ class Setting(pulumi.CustomResource):
 
     @property
     @pulumi.getter
-    def rogue(self) -> pulumi.Output[Optional['outputs.SettingRogue']]:
+    def rogue(self) -> pulumi.Output['outputs.SettingRogue']:
         """
         Rogue site settings
         """
@@ -1804,7 +1804,7 @@ class Setting(pulumi.CustomResource):
 
     @property
     @pulumi.getter
-    def rtsa(self) -> pulumi.Output[Optional['outputs.SettingRtsa']]:
+    def rtsa(self) -> pulumi.Output['outputs.SettingRtsa']:
         """
         Managed mobility
         """
@@ -1845,7 +1845,7 @@ class Setting(pulumi.CustomResource):
 
     @property
     @pulumi.getter
-    def ssr(self) -> pulumi.Output[Optional['outputs.SettingSsr']]:
+    def ssr(self) -> pulumi.Output['outputs.SettingSsr']:
         return pulumi.get(self, "ssr")
 
     @property
@@ -1859,7 +1859,7 @@ class Setting(pulumi.CustomResource):
 
     @property
     @pulumi.getter(name="syntheticTest")
-    def synthetic_test(self) -> pulumi.Output[Optional['outputs.SettingSyntheticTest']]:
+    def synthetic_test(self) -> pulumi.Output['outputs.SettingSyntheticTest']:
         return pulumi.get(self, "synthetic_test")
 
     @property
@@ -1872,7 +1872,7 @@ class Setting(pulumi.CustomResource):
 
     @property
     @pulumi.getter(name="uplinkPortConfig")
-    def uplink_port_config(self) -> pulumi.Output[Optional['outputs.SettingUplinkPortConfig']]:
+    def uplink_port_config(self) -> pulumi.Output['outputs.SettingUplinkPortConfig']:
         """
         AP Uplink port configuration
         """
@@ -1916,7 +1916,7 @@ class Setting(pulumi.CustomResource):
 
     @property
     @pulumi.getter
-    def wids(self) -> pulumi.Output[Optional['outputs.SettingWids']]:
+    def wids(self) -> pulumi.Output['outputs.SettingWids']:
         """
         WIDS site settings
         """
@@ -1924,7 +1924,7 @@ class Setting(pulumi.CustomResource):
 
     @property
     @pulumi.getter
-    def wifi(self) -> pulumi.Output[Optional['outputs.SettingWifi']]:
+    def wifi(self) -> pulumi.Output['outputs.SettingWifi']:
         """
         Wi-Fi site settings
         """
@@ -1937,7 +1937,7 @@ class Setting(pulumi.CustomResource):
 
     @property
     @pulumi.getter(name="zoneOccupancyAlert")
-    def zone_occupancy_alert(self) -> pulumi.Output[Optional['outputs.SettingZoneOccupancyAlert']]:
+    def zone_occupancy_alert(self) -> pulumi.Output['outputs.SettingZoneOccupancyAlert']:
         """
         Zone Occupancy alert site settings
         """


### PR DESCRIPTION
Upstream updated their `v0.3.2` tag, pushing new commits to it.

fixes #359 